### PR TITLE
fix: add-wait-in-rebalancing-to-close-partition

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -80,6 +80,9 @@ akka.kafka.consumer {
     # Disable auto-commit by default
     enable.auto.commit = false
   }
+
+  # Time to wait for pending requests when a partition is closed by a rebalance
+  wait-pending-requests = 5s
 }
 # // #consumer-settings
 

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -26,6 +26,7 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 import scala.annotation.tailrec
 import scala.collection.immutable
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 import scala.util.{Failure, Success}
 
 private[kafka] abstract class SubSourceLogic[K, V, Msg](
@@ -223,7 +224,12 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
         })
 
         def performShutdown() = {
-          completeStage()
+          materializer.scheduleOnce(
+            FiniteDuration(5, "seconds"),
+            new Runnable {
+              override def run(): Unit = completeStage()
+            }
+          )
         }
 
         @tailrec

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -84,15 +84,19 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
   private implicit val askTimeout = Timeout(10000, TimeUnit.MILLISECONDS)
   def partitionAssignedCB(tps: Set[TopicPartition]) = {
     implicit val ec = materializer.executionContext
-    getOffsetsOnAssign.fold(pumpCB.invoke(tps)) { getOffsets =>
-      getOffsets(tps)
+
+    val topicsToBeAssigned = tps -- partitionsToRevoke
+    partitionsToRevoke = partitionsToRevoke -- tps
+
+    getOffsetsOnAssign.fold(pumpCB.invoke(topicsToBeAssigned)) { getOffsets =>
+      getOffsets(topicsToBeAssigned)
         .onComplete {
-          case Failure(ex) => stageFailCB.invoke(new ConsumerFailed(s"Failed to fetch offset for partitions: $tps.", ex))
+          case Failure(ex) => stageFailCB.invoke(new ConsumerFailed(s"Failed to fetch offset for partitions: $topicsToBeAssigned.", ex))
           case Success(offsets) =>
             consumer.ask(KafkaConsumerActor.Internal.Seek(offsets))
-              .map(_ => pumpCB.invoke(tps))
+              .map(_ => pumpCB.invoke(topicsToBeAssigned))
               .recover {
-                case _: AskTimeoutException => stageFailCB.invoke(new ConsumerFailed(s"Consumer failed during seek for partitions: $tps."))
+                case _: AskTimeoutException => stageFailCB.invoke(new ConsumerFailed(s"Consumer failed during seek for partitions: $topicsToBeAssigned."))
               }
         }
     }

--- a/core/src/test/scala/akka/kafka/internal/MyTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/MyTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.kafka.internal
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+import akka.actor.ActorSystem
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.{ConsumerSettings, Subscriptions}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Sink, SinkQueueWithCancel}
+import akka.testkit.TestKit
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest._
+
+// Very dirty way of reproducing https://github.com/akka/reactive-kafka/issues/382
+class MyTest extends TestKit(ActorSystem("IntegrationSpec"))
+  with FlatSpecLike with MustMatchers with BeforeAndAfterAll
+  with BeforeAndAfterEach with TypeCheckedTripleEquals {
+
+  implicit val mat = ActorMaterializer()(system)
+  implicit val ec = system.dispatcher
+  implicit val embeddedKafkaConfig = EmbeddedKafkaConfig(9099, 2189, Map("offsets.topic.replication.factor" -> "1"))
+  val bootstrapServers = s"localhost:${embeddedKafkaConfig.kafkaPort}"
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    EmbeddedKafka.start()
+    EmbeddedKafka.createCustomTopic("test1", partitions = 10)
+    EmbeddedKafka.createCustomTopic("test2", partitions = 10)
+  }
+
+  override def afterAll(): Unit = {
+    shutdown(system, 30.seconds)
+    EmbeddedKafka.stop()
+    super.afterAll()
+  }
+
+  private def extractAll(trie: scala.collection.concurrent.TrieMap[String, Unit], queue: SinkQueueWithCancel[String]): Future[Unit] = {
+    queue.pull().flatMap { opt =>
+      if (opt.isDefined) {
+        trie.put(opt.get, ())
+        extractAll(trie, queue)
+      }
+      else Future.successful(())
+    }
+  }
+
+  ignore must "test that works" in {
+    def getSinkQueue() = {
+      Consumer.plainPartitionedSource(
+        ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+          .withBootstrapServers(bootstrapServers)
+          .withGroupId("mygroup")
+          .withProperty("auto.offset.reset", "earliest"),
+        Subscriptions.topics("test1")
+      ).flatMapMerge(10, _._2)
+        .map(_.value())
+        .runWith(Sink.queue())
+    }
+    val trie = new scala.collection.concurrent.TrieMap[String, Unit]()
+    val queue1 = getSinkQueue()
+    val queue2 = getSinkQueue()
+    extractAll(trie, queue1)
+    extractAll(trie, queue2)
+    Thread.sleep(10000)
+
+    (1 to 2000).par.foreach { i =>
+      EmbeddedKafka.publishStringMessageToKafka("test1", i.toString)
+    }
+    Thread.sleep(10000)
+    println(s"Set size: ${trie.size}")
+    println("Missing: " + ((1 to 2000).toSet -- trie.keys.map(_.toInt)))
+    trie.size must be (2000)
+    queue1.cancel()
+    queue2.cancel()
+  }
+
+  it must "test that doesn't work" in {
+    def getSinkQueue() = {
+      Consumer.plainPartitionedSource(
+        ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+          .withBootstrapServers(bootstrapServers)
+          .withGroupId("mygroup2")
+          .withProperty("auto.offset.reset", "earliest"),
+        Subscriptions.topics("test2")
+      ).flatMapMerge(10, _._2)
+        .map(_.value())
+        .runWith(Sink.queue())
+    }
+    val trie = new scala.collection.concurrent.TrieMap[String, Unit]()
+    val queue1 = getSinkQueue()
+    extractAll(trie, queue1)
+
+    (1 to 1000).foreach { i =>
+      EmbeddedKafka.publishStringMessageToKafka("test2", i.toString)
+    }
+    val queue2 = getSinkQueue()
+    extractAll(trie, queue2)
+    (1001 to 2000).foreach { i =>
+      EmbeddedKafka.publishStringMessageToKafka("test2", i.toString)
+    }
+    Thread.sleep(10000)
+    println(s"Set size: ${trie.size}")
+    println("Missing: " + ((1 to 2000).toSet -- trie.keys.map(_.toInt)))
+    trie.size must be (2000)
+    Thread.sleep(2000)
+    queue1.cancel()
+    queue2.cancel()
+    Thread.sleep(2000)
+  }
+}

--- a/core/src/test/scala/akka/kafka/internal/MyTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/MyTest.scala
@@ -2,6 +2,7 @@
  * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
  * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
  */
+
 package akka.kafka.internal
 
 import scala.concurrent.Future


### PR DESCRIPTION
Add async wait when close partition in order to wait pending requests